### PR TITLE
Fixed #13 - Hide the browser's address bar and footer on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <link rel="manifest" href="/manifest.json">
         <title>Feed the Flames - Simple JS game concept</title>
         <link href="https://fonts.googleapis.com/css?family=Audiowide|Poor+Story" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="css/style.css">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,4 @@
+{
+    "display": "fullscreen",
+    "orientation": "landscape"
+}


### PR DESCRIPTION
Added meta data and manifest.json to index.html. The meta data controls IOS and manifest for android browsers. I only tested on IOS. 